### PR TITLE
[Helm chart] Add readinessProbe to cluster-collector-deploy

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
@@ -75,6 +75,26 @@ spec:
             periodSeconds: {{ .Values.clusterCollector.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.clusterCollector.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.clusterCollector.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: api
+              {{- if .Values.clusterCollector.readinessProbe.httpHeaders }}
+              httpHeaders:
+              {{- range $.Values.clusterCollector.readinessProbe.httpHeaders }}
+                - name: {{ .name }}
+                  value: {{ .value }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.tlsCommunication.enabled }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
+            initialDelaySeconds: {{ .Values.clusterCollector.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.clusterCollector.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.clusterCollector.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.clusterCollector.readinessProbe.failureThreshold }}
           resources:
             {{- toYaml .Values.clusterCollector.resources | nindent 12 }}
           ports:

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -132,6 +132,13 @@ clusterCollector:
     timeoutSeconds: 2
     failureThreshold: 3
 
+  readinessProbe:
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    httpHeaders: []
+
   resources:
     limits:
       cpu: 300m


### PR DESCRIPTION
Specifies a `readinessProbe` on cluster-collector Deployment.
The probe is using port 10050 (api) and path `/health`.

It can be configured as follows (sample/default values):
```yaml
  readinessProbe:
    initialDelaySeconds: 3
    periodSeconds: 10
    timeoutSeconds: 2
    failureThreshold: 3
    httpHeaders:
      - name: status
        value: available
```

For discussion around the original requirement for this, see #17.