### PR TITLE
[Helm chart] Remove CPU limits from default values.yaml

### DIFF
--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -206,7 +206,6 @@ nodeCollector:
 
     resources:
       limits:
-        cpu: 300m
         memory: 200Mi
       requests:
         cpu: 150m
@@ -230,7 +229,6 @@ nodeCollector:
 
     resources:
       limits:
-        cpu: 300m
         memory: 200Mi
       requests:
         cpu: 150m
@@ -254,7 +252,6 @@ nodeCollector:
 
     resources:
       limits:
-        cpu: 300m
         memory: 200Mi
       requests:
         cpu: 150m


### PR DESCRIPTION
Based on the blog posts of [Nathan Yellin](https://home.robusta.dev/team/natan-yellin) [^1][^2], there are some best practices for resource requests and limits:

CPU:
1. Use CPU requests for everything
2. Make sure they are accurate
3. Do **not** use CPU limits.

Memory:

1. Always use memory limits
2. Always use memory requests
3. Always set your memory requests equal to your limits

The default [values.yaml](deploy/charts/checkmk/values.yaml) still declares `resources.limits.cpu`, so I removed those.
Just a proposal, still when there _really_ is the need to specify those, it can still be done. 

[^1]: [For the love of god, stop using CPU limits on Kubernetes (updated)](https://home.robusta.dev/blog/stop-using-cpu-limits)
[^2]: [What everyone should know about Kubernetes memory limits, OOMKilled pods, and pizza parties](https://home.robusta.dev/blog/kubernetes-memory-limit)