### PR TITLE
[Helm Chart][Bugfix] Move separator in ingress.yaml behind whitespace-stripping directive

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-ingress.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-ingress.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.clusterCollector.ingress.enabled -}}
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
### Issue 
`helm lint` fails when ran against the Helm chart.

Minimal example to reproduce:
```bash
helm pull https://github.com/Checkmk/checkmk_kube_agent/releases/download/v1.4.0/checkmk-kube-agent-helm-1.4.0.tgz
helm lint ./checkmk-kube-agent-helm-1.4.0.tgz --set clusterCollector.ingress.enabled=true
```
Error message is:
```
[ERROR] templates/cluster-collector-ingress.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: networking.k8s.io/v1
```
### Root cause
Reason is that the directive in `cluster-collector-ingress.yaml` is stripping the whitespace after `---`, therefore creating invalid YAML. It is pretty good described in this issue/comment --> [here](https://github.com/helm/helm/issues/10149#issuecomment-929205040).


### Solution
... is to move the separator behind the whitespace-stripping directive, as done in this PR :smiley: 