### PR TITLE
Adding k3s support in helm chart

### DIFF
--- a/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
@@ -62,9 +62,9 @@ spec:
           args:
           {{- with .Values.nodeCollector.cadvisor.additionalArgs }}
             {{ toYaml . | nindent 12 }}
-          {{- if $.Values.k3s.enabled }}
-            - "--containerd=/run/k3s/containerd/containerd.sock"
           {{- end }}
+          {{- if .Values.containerdOverride }}
+            - --containerd={{ .Values.containerdOverride }}
           {{- end }}
           resources:
             {{- toYaml .Values.nodeCollector.cadvisor.resources | nindent 12 }}

--- a/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
@@ -62,6 +62,9 @@ spec:
           args:
           {{- with .Values.nodeCollector.cadvisor.additionalArgs }}
             {{ toYaml . | nindent 12 }}
+          {{- if $.Values.k3s.enabled }}
+            - "--containerd=/run/k3s/containerd/containerd.sock"
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.nodeCollector.cadvisor.resources | nindent 12 }}

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -6,8 +6,9 @@ nameOverride: ""
 fullnameOverride: ""
 kubeVersionOverride: ""
 
-k3s:
-  enabled: false
+## k3s and Rancher RKE2 host containerd in a different location.
+## If you are using one of them, or containerd is located in an alternate location, please uncomment / adapt the override.   
+#containerdOverride: "/run/k3s/containerd/containerd.sock"
 
 tlsCommunication:
   enabled: false

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -6,6 +6,9 @@ nameOverride: ""
 fullnameOverride: ""
 kubeVersionOverride: ""
 
+k3s:
+  enabled: false
+
 tlsCommunication:
   enabled: false
   verifySsl: false


### PR DESCRIPTION
Normally you would have to edit the DaemonSet to add the k3s containerd path so that the cluster collector would get metrics properly but with this you can enable k3s in the values.yml to do it for you. 

I tested this on a brand new k3s instance and it works for me with data in the checkmk dashboard. 