### PR TITLE
[Helm Chart] PSP deprecation, migrate to proper usage of seccompProfile

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-psp.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-psp.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if ge (int .Capabilities.KubeVersion.Minor) 25 }}
+{{- fail "PodSecurityPolicies (PSPs) were deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. Please make sure to disable PSPs." }}
+{{- end }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/deploy/charts/checkmk/templates/node-collector-container-metrics-psp.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-container-metrics-psp.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if ge (int .Capabilities.KubeVersion.Minor) 25 }}
+{{- fail "PodSecurityPolicies (PSPs) were deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. Please make sure to disable PSPs." }}
+{{- end }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/deploy/charts/checkmk/templates/node-collector-machine-sections-psp.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-machine-sections-psp.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if ge (int .Capabilities.KubeVersion.Minor) 25 }}
+{{- fail "PodSecurityPolicies (PSPs) were deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. Please make sure to disable PSPs." }}
+{{- end }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -29,6 +29,8 @@ image:
   tag: "main_2022.03.02" # main_<YYYY.MM.DD>
 
 rbac:
+  # PodSecurityPolicies (PSPs) were deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25.
+  # This section will be removed as soon as we do not support versions below v1.25 anymore.
   pspEnabled: false
   pspAnnotations:
     ## Specify psp annotations
@@ -87,13 +89,14 @@ clusterCollector:
   # can be: "debug", "info", "warning" (default), "critical"
   logLevel: warning
 
-  podAnnotations:
-    seccomp.security.alpha.kubernetes.io/pod: runtime/default
+  podAnnotations: {}
 
   podSecurityContext: {}
     # fsGroup: 2000
 
   securityContext:
+    seccompProfile:
+      type: RuntimeDefault
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -162,8 +165,7 @@ nodeCollector:
   minReadySeconds: 15
 
   # Annotations to be added to node-collector pods
-  podAnnotations:
-    seccomp.security.alpha.kubernetes.io/pod: runtime/default
+  podAnnotations: {}
 
   podSecurityContext: {}
     # fsGroup: 2000
@@ -201,6 +203,8 @@ nodeCollector:
       - "--storage_duration=1m0s"
 
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       allowPrivilegeEscalation: false
       capabilities:
         drop:
@@ -223,6 +227,8 @@ nodeCollector:
       pullPolicy: IfNotPresent
 
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       allowPrivilegeEscalation: false
       capabilities:
         drop:
@@ -247,6 +253,8 @@ nodeCollector:
       pullPolicy: IfNotPresent
 
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       allowPrivilegeEscalation: false
       capabilities:
         drop:


### PR DESCRIPTION
- note on PSP deprecation and removal in README.md
- check is k8s >= v1.25, if so and PSPs are enabled, fail
- proper usage of `seccompProfile` in `securityContext` of containers