### PR TITLE
fix: cadvisor: make /var/run read-only again

### DIFF
--- a/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
@@ -70,12 +70,9 @@ spec:
               name: http
               protocol: TCP
           volumeMounts:
-            - name: no-api-access
-              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-              readOnly: true
             - name: var-run
               mountPath: /var/run
-              # readOnly: true # needs to be disabled, otherwise we cannot deny api-access
+              readOnly: true
             - name: sys
               mountPath: /sys
               readOnly: true
@@ -117,8 +114,6 @@ spec:
             {{- toYaml .Values.nodeCollector.containerMetricsCollector.resources | nindent 12 }}
       terminationGracePeriodSeconds: 30
       volumes:
-        - name: no-api-access
-          emptyDir: {}
         - name: var-run
           hostPath:
             path: /var/run


### PR DESCRIPTION
removes workaround to overwrite serviceaccount token with an emptyDir, so we can make `/var/run` readOnly again, as is the standard for cadvisor (security trade-off in the end).