### PR TITLE
Add chart option for cluster-collector to set cache-maxsize if a k8s-cluster generate more than 10000 metrics

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
@@ -47,6 +47,7 @@ spec:
           args:
             - "--log-level={{ .Values.clusterCollector.logLevel }}"
             - "--address={{ default "0.0.0.0" .Values.clusterCollector.address }}"
+            - "--cache-maxsize={{ defaulut "10000" .Values.clusterCollector.cacheMaxsize }}"
             - "--reader-whitelist={{ .Release.Namespace }}:{{ template "checkmk.serviceAccountName.checkmk" . }}"
             - "--writer-whitelist={{ .Release.Namespace }}:{{ template "checkmk.serviceAccountName.nodeCollector.containerMetricsCollector" . }},{{ .Release.Namespace }}:{{ template "checkmk.serviceAccountName.nodeCollector.machineSectionsCollector" . }}"
           {{- if .Values.tlsCommunication.enabled }}

--- a/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
@@ -47,7 +47,7 @@ spec:
           args:
             - "--log-level={{ .Values.clusterCollector.logLevel }}"
             - "--address={{ default "0.0.0.0" .Values.clusterCollector.address }}"
-            - "--cache-maxsize={{ defaulut "10000" .Values.clusterCollector.cacheMaxsize }}"
+            - "--cache-maxsize={{ default "10000" .Values.clusterCollector.cacheMaxsize }}"
             - "--reader-whitelist={{ .Release.Namespace }}:{{ template "checkmk.serviceAccountName.checkmk" . }}"
             - "--writer-whitelist={{ .Release.Namespace }}:{{ template "checkmk.serviceAccountName.nodeCollector.containerMetricsCollector" . }},{{ .Release.Namespace }}:{{ template "checkmk.serviceAccountName.nodeCollector.machineSectionsCollector" . }}"
           {{- if .Values.tlsCommunication.enabled }}

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -97,6 +97,9 @@ clusterCollector:
   # can be: "debug", "info", "warning" (default), "critical"
   logLevel: warning
 
+  # cacheMaxsize set the maximum number of metric entries the cluster collector can hold at a time
+  cacheMaxsize: "10000"
+
   podAnnotations: {}
 
   podSecurityContext: {}


### PR DESCRIPTION
Hi there,

For days I have been looking for the reason why the metrics of my large Kubernetes clusters kept getting lost. During my search, I came across the collector option --cache-maxsize, which needs to be increased to solve the problem. This pull request now made it possible to set this value via the helmet chart.

Greetings
schmidax