### PR TITLE
add cgroup v2 and containerd socket notes to values.yaml

### DIFF
--- a/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-container-metrics-ds.yaml
@@ -87,6 +87,11 @@ spec:
             - name: docker
               mountPath: /var/lib/docker
               readOnly: true
+            {{- if and .Values.nodeCollector.cadvisor.containerdSocket .Values.nodeCollector.cadvisor.containerdSocket.enabled }}
+            - name: containerdsock
+              mountPath: {{ .Values.nodeCollector.cadvisor.containerdSocket.mountPath | quote }}
+              readOnly: true
+            {{- end }}
         - name: container-metrics-collector
           securityContext:
             {{- toYaml .Values.nodeCollector.containerMetricsCollector.securityContext | nindent 12 }}
@@ -133,6 +138,12 @@ spec:
         - name: docker
           hostPath:
             path: /var/lib/docker
+        {{- if and .Values.nodeCollector.cadvisor.containerdSocket .Values.nodeCollector.cadvisor.containerdSocket.enabled }}
+        - name: containerdsock
+          hostPath:
+            path: {{ .Values.nodeCollector.cadvisor.containerdSocket.hostPath | quote }}
+            type: Socket
+        {{- end }}
       {{- if .Values.tlsCommunication.enabled }}
         - name: checkmk-ca-cert
           secret:

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -237,6 +237,35 @@ nodeCollector:
         cpu: 150m
         memory: 200Mi
 
+    # Configuration for containerd socket (used by cadvisor in the node collector).
+    # This section is optional and only needed if CPU/Memory metrics are missing the required labels.
+    # Access to the container runtime socket (e.g., for metrics collection).
+    # Known limitation:
+    # - When Kubernetes nodes run with cgroup v2 (common in newer distros),
+    #   cAdvisor cannot properly map container metadata (pod name, namespace, labels)
+    #   from cgroups alone.
+    # - To work around this, the container runtime socket must be mounted inside the cAdvisor pod
+    #   so that cAdvisor can query containerd directly for metadata via its gRPC interface.
+    #
+    # To locate the correct socket path on your host node, run:
+    #   find / -type s -name 'containerd.sock' 2>/dev/null
+    #
+    # The path varies depending on your Kubernetes setup:
+    #   - MicroK8s: /var/snap/microk8s/common/run/containerd.sock
+    #   - Standard containerd: /run/containerd/containerd.sock
+    #   - k3s: /run/k3s/containerd/containerd.sock
+    #
+    # mountPath is where the socket is available inside the container.
+    # hostPath is the full path to the socket file on the Kubernetes node.
+    #
+    # Example to enable:
+    # containerdSocket:
+    #   enabled: true
+    #   name: containerdsock
+    #   mountPath: /var/snap/microk8s/common/run/containerd.sock
+    #   hostPath: /var/snap/microk8s/common/run/containerd.sock
+
+
   containerMetricsCollector:
     image:
       repository: checkmk/kubernetes-collector


### PR DESCRIPTION
- Document known limitation of cAdvisor with cgroup v2 in Kubernetes setups using containerd.

- Explain why mounting containerd socket is needed to get proper container labels in metrics.

- Add instructions to check if cgroup v2 is in use.

- This configuration is optional and may not be required for each K8 setup