### PR TITLE
Don't set resource requests and limits anymore

### DIFF
--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -151,14 +151,17 @@ clusterCollector:
     timeoutSeconds: 2
     failureThreshold: 3
     httpHeaders: [ ]
-  resources:
-    limits:
-      cpu: 300m
-      memory: 200Mi
-    requests:
-      cpu: 150m
-      memory: 200Mi
 
+  ## Configure resource requests and limits
+  ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 500Mi
+    # requests:
+    #   cpu: 150m
+    #   memory: 200Mi
+  
   nodeSelector: {}
 
   tolerations: []
@@ -229,13 +232,15 @@ nodeCollector:
       privileged: false
       readOnlyRootFilesystem: true
 
-    resources:
-      limits:
-        cpu: 300m
-        memory: 200Mi
-      requests:
-        cpu: 150m
-        memory: 200Mi
+    ## Configure resource requests and limits
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources: {}
+      # limits:
+      #   cpu: 300m
+      #   memory: 500Mi
+      # requests:
+      #   cpu: 150m
+      #   memory: 200Mi
 
   containerMetricsCollector:
     image:
@@ -255,13 +260,15 @@ nodeCollector:
       runAsNonRoot: true
       runAsUser: 10001
 
-    resources:
-      limits:
-        cpu: 300m
-        memory: 200Mi
-      requests:
-        cpu: 150m
-        memory: 200Mi
+    ## Configure resource requests and limits
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources: {}
+      # limits:
+      #   cpu: 300m
+      #   memory: 500Mi
+      # requests:
+      #   cpu: 150m
+      #   memory: 200Mi
 
   machineSectionsCollector:
     image:
@@ -281,13 +288,15 @@ nodeCollector:
       runAsNonRoot: true
       runAsUser: 10001
 
-    resources:
-      limits:
-        cpu: 300m
-        memory: 200Mi
-      requests:
-        cpu: 150m
-        memory: 200Mi
+    ## Configure resource requests and limits
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources: {}
+      # limits:
+      #   cpu: 300m
+      #   memory: 500Mi
+      # requests:
+      #   cpu: 150m
+      #   memory: 200Mi
 
     checkmkAgentTimeout: 5
 


### PR DESCRIPTION
In larger environments, we saw OOMKilled on the cluster collector showing that the limit of 200Mi is too low.

After discussing it in detail and looking at best practices, I believe it makes more sense to not define any limits and requests, but rather leave that to the Kubernetes team.
We propose sensible levels, but only the actual Kubernetes team will know the size, requirements and limitations their cluster has