### PR TITLE
Don't show VIP anymore in SERVICE_IP output

### DIFF
--- a/deploy/charts/checkmk/templates/NOTES.txt
+++ b/deploy/charts/checkmk/templates/NOTES.txt
@@ -14,8 +14,9 @@ NodePort:
 {{- else if contains "LoadBalancer" .Values.clusterCollector.service.type }}
 LoadBalancer:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           It might return both hostname and IP. Please clean up yourself in this case by either one.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "checkmk.fullname" . }}-cluster-collector'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "checkmk.fullname" . }}-cluster-collector --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}");
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "checkmk.fullname" . }}-cluster-collector -o jsonpath="{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}")
   echo http://$SERVICE_IP:{{ .Values.clusterCollector.service.port }}
 {{- else if contains "ClusterIP" .Values.clusterCollector.service.type }}
 ClusterIP:


### PR DESCRIPTION
This is a possible output. The current command includes ipMode in SERVICE_IP, which is not correct. 
```
    "status": {
        "loadBalancer": {
            "ingress": [
                {
                    "ip": "xx.xxx.xxx.xxx",
                    "ipMode": "VIP"
                }
            ]
        }
    }
```